### PR TITLE
FEAT: 프로젝트 관련 API 및 CORS설정 추가

### DIFF
--- a/src/main/java/com/webproject/jandi_ide_backend/config/SecurityConfig.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/config/SecurityConfig.java
@@ -4,8 +4,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -14,6 +20,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // lambda 스타일로 커스텀 CORS 설정 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // 세션을 사용하지 않도록 설정 (stateless)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 모든 요청에 대해 인증 없이 접근을 허용합니다.
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
                 // CSRF 보호가 필요하지 않다면 비활성화합니다.
@@ -22,5 +32,21 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults())
                 .formLogin(form -> form.disable());
         return http.build();
+    }
+
+    // CORS 설정 정의
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); // 쿠키 등 인증 정보 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config); // 모든 경로에 대해 적용
+
+        return source;
     }
 }

--- a/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
@@ -17,7 +17,11 @@ public enum CustomErrorCodes implements CustomErrorCodeInterface {
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_JWT_TOKEN", "Invalid JWT token"), // 유효하지 JWT 토큰
     GITHUB_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "GITHUB_LOGIN_FAILED", "GitHub login failed"), // 깃헙 로그인 실패
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "User not found"), // 유저를 찾을 수 없음
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "PERMISSION_DENIED", "Permission denied"); // 권한 없음
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_NOT_FOUND", "Project not found"), // 프로젝트를 찾을 수 없음
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "PERMISSION_DENIED", "Permission denied"), // 권한 없음
+
+    // 500번대 에러
+    DB_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DB_OPERATION_FAILED", "Database operation failed"); // DB 작업 실패
 
     
 

--- a/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
@@ -16,9 +16,12 @@ public enum CustomErrorCodes implements CustomErrorCodeInterface {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_JWT_TOKEN", "Expired JWT token"), // 만료된 JWT 토큰
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_JWT_TOKEN", "Invalid JWT token"), // 유효하지 JWT 토큰
     GITHUB_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "GITHUB_LOGIN_FAILED", "GitHub login failed"), // 깃헙 로그인 실패
+
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "User not found"), // 유저를 찾을 수 없음
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_NOT_FOUND", "Project not found"), // 프로젝트를 찾을 수 없음
+
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "PERMISSION_DENIED", "Permission denied"), // 권한 없음
+
 
     // 500번대 에러
     DB_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DB_OPERATION_FAILED", "Database operation failed"); // DB 작업 실패

--- a/src/main/java/com/webproject/jandi_ide_backend/project/controller/ProjectController.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/controller/ProjectController.java
@@ -1,0 +1,120 @@
+package com.webproject.jandi_ide_backend.project.controller;
+
+import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
+import com.webproject.jandi_ide_backend.global.error.CustomException;
+import com.webproject.jandi_ide_backend.project.dto.ProjectCreateRequestDTO;
+import com.webproject.jandi_ide_backend.project.dto.ProjectResponseDTO;
+import com.webproject.jandi_ide_backend.project.dto.ProjectUpdateRequestDTO;
+import com.webproject.jandi_ide_backend.project.service.ProjectService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 대표 프로젝트 관련 API를 처리하는 컨트롤러.
+ */
+@Tag(name="Project", description = "대표 프로젝트 관련 API")
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService){
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    @Operation(summary = "대표 프로젝트 추가", description = "자신의 대표 프로젝트를 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추가 성공",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProjectResponseDTO.class)))
+            ),
+    })
+    public ResponseEntity<ProjectResponseDTO> postProject(
+            @Parameter(
+                    name = "Authorization",
+                    description = "액세스 토큰을 입력해주세요",
+                    required = true,
+                    example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+            @RequestHeader("Authorization") String token,
+            @RequestBody ProjectCreateRequestDTO requestDTO
+    ){
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new CustomException(CustomErrorCodes.INVALID_JWT_TOKEN);
+        }
+
+
+        String accessToken = token.replace("Bearer ", "").trim();
+        ProjectResponseDTO projectResponseDTO = projectService.postProject(accessToken, requestDTO);
+        return ResponseEntity.ok(projectResponseDTO);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "대표 프로젝트 수정", description = "자신의 대표 프로젝트를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ProjectResponseDTO.class))
+            ),
+    })
+    public ResponseEntity<ProjectResponseDTO> putProject(
+            @Parameter(
+                    name = "Authorization",
+                    description = "액세스 토큰을 입력해주세요",
+                    required = true,
+                    example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+            @RequestHeader("Authorization") String token,
+            @PathVariable int id,
+            @RequestBody ProjectUpdateRequestDTO requestDTO
+    ){
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new CustomException(CustomErrorCodes.INVALID_JWT_TOKEN);
+        }
+
+        String accessToken = token.replace("Bearer ", "").trim();
+        ProjectResponseDTO projectResponseDTO = projectService.updateProject(accessToken,id, requestDTO);
+        return ResponseEntity.ok(projectResponseDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "대표 프로젝트 삭제", description = "자신의 대표 프로젝트를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "프로젝트 삭제 성공")
+                    )
+            )
+    })
+    public ResponseEntity<String> deleteProject(
+            @Parameter(
+                    name = "Authorization",
+                    description = "액세스 토큰을 입력해주세요",
+                    required = true,
+                    example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+            @RequestHeader("Authorization") String token,
+            @PathVariable int id
+    ){
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new CustomException(CustomErrorCodes.INVALID_JWT_TOKEN);
+        }
+
+        String accessToken = token.replace("Bearer ", "").trim();
+        projectService.deleteProject(accessToken, id);
+
+        return ResponseEntity.ok("프로젝트 삭제 성공");
+    }
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/controller/ProjectController.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/controller/ProjectController.java
@@ -2,14 +2,16 @@ package com.webproject.jandi_ide_backend.project.controller;
 
 import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
 import com.webproject.jandi_ide_backend.global.error.CustomException;
+import com.webproject.jandi_ide_backend.project.dto.BlobResponseDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectCreateRequestDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectResponseDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectUpdateRequestDTO;
+import com.webproject.jandi_ide_backend.project.entity.Project;
+import com.webproject.jandi_ide_backend.project.repository.ProjectRepository;
 import com.webproject.jandi_ide_backend.project.service.ProjectService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,6 +21,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
+
 /**
  * 대표 프로젝트 관련 API를 처리하는 컨트롤러.
  */
@@ -27,16 +31,18 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/projects")
 public class ProjectController {
     private final ProjectService projectService;
+    private final ProjectRepository projectRepository;
 
-    public ProjectController(ProjectService projectService){
+    public ProjectController(ProjectService projectService, ProjectRepository projectRepository) {
         this.projectService = projectService;
+        this.projectRepository = projectRepository;
     }
 
     @PostMapping
     @Operation(summary = "대표 프로젝트 추가", description = "자신의 대표 프로젝트를 추가합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "추가 성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProjectResponseDTO.class)))
+                    content = @Content(schema = @Schema(implementation = ProjectResponseDTO.class))
             ),
     })
     public ResponseEntity<ProjectResponseDTO> postProject(
@@ -56,6 +62,34 @@ public class ProjectController {
 
         String accessToken = token.replace("Bearer ", "").trim();
         ProjectResponseDTO projectResponseDTO = projectService.postProject(accessToken, requestDTO);
+        return ResponseEntity.ok(projectResponseDTO);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "특정 프로젝트 조회", description = "특정 프로젝트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = Object.class))
+            ),
+    })
+    public ResponseEntity<?> getProject(
+            @Parameter(
+                    name = "Authorization",
+                    description = "액세스 토큰을 입력해주세요",
+                    required = true,
+                    example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+            @RequestHeader("Authorization") String token,
+            @PathVariable int id
+    ){
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new CustomException(CustomErrorCodes.INVALID_JWT_TOKEN);
+        }
+
+        String accessToken = token.replace("Bearer ", "").trim();
+        Project project = projectRepository.findById(id)
+                .orElseThrow(() -> new CustomException(CustomErrorCodes.PROJECT_NOT_FOUND));
+        Object projectResponseDTO = projectService.getProject(accessToken,project.getOwner().getGithubUsername(),project.getGithubName());
         return ResponseEntity.ok(projectResponseDTO);
     }
 
@@ -116,5 +150,35 @@ public class ProjectController {
         projectService.deleteProject(accessToken, id);
 
         return ResponseEntity.ok("프로젝트 삭제 성공");
+    }
+
+    @GetMapping("/{id}/blob")
+    @Operation(summary = "특정 프로젝트의 blob 조회", description = "특정 프로젝트의 blob을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BlobResponseDTO.class))
+            ),
+    })
+    public ResponseEntity<BlobResponseDTO> getProjectBlob(
+            @Parameter(
+                    name = "Authorization",
+                    description = "액세스 토큰을 입력해주세요",
+                    required = true,
+                    example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+            @RequestHeader("Authorization") String token,
+            @PathVariable int id,
+            @RequestParam(value = "sha", required = true) String sha
+    ){
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new CustomException(CustomErrorCodes.INVALID_JWT_TOKEN);
+        }
+
+        String accessToken = token.replace("Bearer ", "").trim();
+        projectRepository.findById(id)
+                .orElseThrow(() -> new CustomException(CustomErrorCodes.PROJECT_NOT_FOUND));
+
+        BlobResponseDTO projectResponseDTO = projectService.getProjectBlob(accessToken,id, sha);
+        return ResponseEntity.ok(projectResponseDTO);
     }
 }

--- a/src/main/java/com/webproject/jandi_ide_backend/project/dto/BlobResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/dto/BlobResponseDTO.java
@@ -1,0 +1,25 @@
+package com.webproject.jandi_ide_backend.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class BlobResponseDTO {
+    @Schema (description = "해당 blob 의 해시값", example = "5sdb1sd5b3sdv5v1")
+    private String sha;
+
+    @Schema (description = "깃헙 내부에서 사용하는 고유 식별자", example = "1asdvsd65dv5sb1sdb1rtu5")
+    private String node_id;
+
+    @Schema (description = "해당 blob 의 url", example = "https://api.github.com/repos/Yoonhwi/jandi_plan_frontend/git/blobs/5sdb1sd5b3sdv5v1")
+    private String url;
+
+    @Schema (description = "해당 blob 의 크기", example = "640")
+    private Long size;
+
+    @Schema (description = "파일의 내용이 base64로 인코딩된 값 디코딩 시 실제 파일내용", example = "15656sdavasdvsv5115")
+    private String content;
+
+    @Schema (description = "파일의 인코딩 방식", example = "base64")
+    private String encoding;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectCreateRequestDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectCreateRequestDTO.java
@@ -1,0 +1,30 @@
+package com.webproject.jandi_ide_backend.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Data
+@Schema(description = "프로젝트 생성 요청")
+public class ProjectCreateRequestDTO {
+    @NotBlank(message = "프로젝트 이름은 필수입니다")
+    @Size(min = 1, max = 100, message = "프로젝트 이름은 1-100자 사이여야 합니다")
+    @Schema(description = "프로젝트 이름", example = "algorithm")
+    private String name;
+
+    @NotBlank(message = "GitHub 레포지토리 이름은 필수입니다")
+    @Size(min = 1, max = 100, message = "GitHub 레포지토리 이름은 1-100자 사이여야 합니다")
+    @Schema(description = "GitHub 레포지토리 이름", example = "algorithm")
+    private String githubName;
+
+    @Size(max = 500, message = "프로젝트 설명은 500자 이하여야 합니다")
+    @Schema(description = "프로젝트 설명", example = "practice algorithm")
+    private String description;
+
+    @NotBlank(message = "프로젝트 URL은 필수입니다")
+    @Size(max = 255, message = "URL은 255자 이하여야 합니다")
+    @Schema(description = "GitHub 프로젝트 URL", example = "https://github.com/username/algorithm")
+    private String url;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectResponseDTO.java
@@ -1,0 +1,34 @@
+package com.webproject.jandi_ide_backend.project.dto;
+
+import com.webproject.jandi_ide_backend.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ProjectResponseDTO {
+    @Schema(description = "프로젝트 ID", example = "1")
+    private Integer id;
+
+    @Schema(description = "프로젝트 이름", example = "algorithm")
+    private String name;
+
+    @Schema(description = "GitHub 레포지토리 이름", example = "algorithm")
+    private String githubName;
+
+    @Schema(description = "프로젝트 설명", example = "practice algorithm")
+    private String description;
+
+    @Schema(description = "프로젝트 URL", example = "https://github.com/username/algorithm")
+    private String url;
+
+    @Schema(description = "유저 정보")
+    private User owner;
+
+    @Schema(description = "생성 일시", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2023-10-15T14:30:00")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectUpdateRequestDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/dto/ProjectUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.webproject.jandi_ide_backend.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectUpdateRequestDTO {
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/entity/Project.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/entity/Project.java
@@ -29,6 +29,10 @@ public class Project {
     @Column(nullable = false)
     private String name;
 
+    // GitHub 레포지토리 원본 이름 (불변)
+    @Column(nullable = false)
+    private String githubName;
+
     // 프로젝트에 대한 상세 설명을 저장 (긴 텍스트를 저장할 수 있도록 TEXT 타입 사용)
     @Column(columnDefinition = "TEXT")
     private String description;

--- a/src/main/java/com/webproject/jandi_ide_backend/project/repository/ProjectRepository.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/repository/ProjectRepository.java
@@ -1,0 +1,13 @@
+package com.webproject.jandi_ide_backend.project.repository;
+
+import com.webproject.jandi_ide_backend.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectRepository  extends JpaRepository<Project, Long> {
+    Optional<Project> findById(Integer id);
+
+    List<Project> findByOwner_Id(Integer userId);
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/project/service/ProjectService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package com.webproject.jandi_ide_backend.project.service;
 
 import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
 import com.webproject.jandi_ide_backend.global.error.CustomException;
+import com.webproject.jandi_ide_backend.project.dto.BlobResponseDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectCreateRequestDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectResponseDTO;
 import com.webproject.jandi_ide_backend.project.dto.ProjectUpdateRequestDTO;
@@ -12,7 +13,14 @@ import com.webproject.jandi_ide_backend.security.TokenInfo;
 import com.webproject.jandi_ide_backend.user.entity.User;
 import com.webproject.jandi_ide_backend.user.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -29,7 +37,44 @@ public class ProjectService {
     }
 
     /**
-     * 대표 프로젝트 추가
+     * 특정 유저의 대표 프로젝트 조회
+     * @param accessToken: 사용자 액세스 토큰
+     * @param id: 사용자 ID
+     * @return List<ProjectResponseDTO>
+     */
+    public List<ProjectResponseDTO> getProjects(String accessToken , Integer id) {
+        // 1. 토큰 검증
+        jwtTokenProvider.decodeToken(accessToken);
+
+        // 2. 사용자 정보 조회
+        User user = userRepository.findById(id).orElseThrow(() -> new CustomException(CustomErrorCodes.USER_NOT_FOUND));
+
+        // 3. 프로젝트 정보 조회
+        List<Project> projects = projectRepository.findByOwner_Id(user.getId());
+
+        // 4. 응답 DTO 반환
+        return projects.stream().map(this::convertToDTO).toList();
+    }
+
+    /**
+     * 특정 유저의 레포지토리 트리 조회
+     * @param accessToken: 사용자 액세스 토큰
+     * @param githubUsername: 깃허브 사용자 이름
+     * @param githubReponame: 깃허브 레포지토리 이름
+     * @return 레포지토리 트리 정보
+     */
+    public Object getProject(String accessToken, String githubUsername, String githubReponame) {
+        TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
+        String githubToken = tokenInfo.getGithubToken();
+
+        String defaultBranch = getDefaultBranch(githubToken, githubUsername, githubReponame);
+        log.info("Default branch: {}", defaultBranch);
+
+        return getRepoTrees(defaultBranch,githubUsername,githubReponame,githubToken);
+    }
+
+    /**
+     * 내 대표 프로젝트 추가
      * @param accessToken: 사용자 액세스 토큰
 //     * @param id: 사용자 ID
      * @param requestDTO: 프로젝트 요청 DTO
@@ -63,7 +108,7 @@ public class ProjectService {
     }
 
     /**
-     * 대표 프로젝트 수정
+     * 내 대표 프로젝트 수정
      * @param accessToken: 사용자 액세스 토큰
      * @param id: 프로젝트 ID
      * @param requestDTO: 프로젝트 요청 DTO
@@ -98,6 +143,11 @@ public class ProjectService {
         return convertToDTO(project);
     }
 
+    /**
+     * 내 대표 프로젝트 삭제
+     * @param accessToken: 사용자 액세스 토큰
+     * @param id: 프로젝트 ID
+     */
     public void deleteProject(String accessToken,Integer id){
         // 1. 토큰 검증
         TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
@@ -120,6 +170,100 @@ public class ProjectService {
         }
     }
 
+    public BlobResponseDTO getProjectBlob(String accessToken,Integer id, String sha){
+        TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
+        String githubId = tokenInfo.getGithubId();
+
+        User user = userRepository.findByGithubId(githubId).orElseThrow(() -> new CustomException(CustomErrorCodes.USER_NOT_FOUND));
+        Project project = projectRepository.findById(id).orElseThrow(() -> new CustomException(CustomErrorCodes.PROJECT_NOT_FOUND));
+
+        // 1. 레포지토리의 default branch 조회
+        String githubUsername = user.getGithubUsername();
+        String githubReponame = project.getGithubName();
+        String githubToken = tokenInfo.getGithubToken();
+
+        // 2. 레포지토리 트리 조회
+        return getRepoBlob(sha, githubUsername, githubReponame, githubToken);
+    }
+
+    /**
+     * 레포지토리의 default branch 조회
+     * @param githubToken: 깃허브 토큰
+     * @param githubUsername: 깃허브 사용자 이름
+     * @param githubReponame: 깃허브 레포지토리 이름
+     * @return default branch 이름
+     */
+    private String getDefaultBranch(String githubToken, String githubUsername, String githubReponame) {
+        String repoUrl = "https://api.github.com/repos/" + githubUsername + "/" + githubReponame;
+
+        // 1. 해당 레포 특정 조회 (default branch 를 가져옴)
+        try{
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(githubToken);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    repoUrl,
+                    HttpMethod.GET,
+                    request,
+                    Map.class
+            );
+
+            Map<String, Object> responseBody = response.getBody();
+
+            return (String) responseBody.get("default_branch");
+        } catch (Exception e) {
+            throw new RuntimeException("Error fetching default branch: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 레포지토리의 트리 조회
+     * @param branch: default 브랜치 이름
+     * @param githubUsername: 깃허브 사용자 이름
+     * @param githubReponame: 깃허브 레포지토리 이름
+     * @return 레포지토리 트리 정보
+     */
+    private Object getRepoTrees(String branch, String githubUsername, String githubReponame,String githubToken) {
+        String branchUrl = UriComponentsBuilder
+                .fromHttpUrl("https://api.github.com/repos/" + githubUsername + "/" + githubReponame + "/git/trees/" + branch)
+                .queryParam("recursive", "1")
+                .build()
+                .toUriString();
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(githubToken);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                branchUrl,
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        return response.getBody();
+    }
+
+    private BlobResponseDTO getRepoBlob(String sha, String githubUsername, String githubReponame,String githubToken) {
+        String blobUrl = "https://api.github.com/repos/" + githubUsername + "/" + githubReponame + "/git/blobs/" + sha;
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(githubToken);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<BlobResponseDTO> response = restTemplate.exchange(
+                blobUrl,
+                HttpMethod.GET,
+                request,
+                BlobResponseDTO.class
+        );
+
+        return response.getBody();
+    }
 
     private ProjectResponseDTO convertToDTO(Project project) {
         ProjectResponseDTO dto = new ProjectResponseDTO();

--- a/src/main/java/com/webproject/jandi_ide_backend/project/service/ProjectService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/project/service/ProjectService.java
@@ -1,0 +1,136 @@
+package com.webproject.jandi_ide_backend.project.service;
+
+import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
+import com.webproject.jandi_ide_backend.global.error.CustomException;
+import com.webproject.jandi_ide_backend.project.dto.ProjectCreateRequestDTO;
+import com.webproject.jandi_ide_backend.project.dto.ProjectResponseDTO;
+import com.webproject.jandi_ide_backend.project.dto.ProjectUpdateRequestDTO;
+import com.webproject.jandi_ide_backend.project.entity.Project;
+import com.webproject.jandi_ide_backend.project.repository.ProjectRepository;
+import com.webproject.jandi_ide_backend.security.JwtTokenProvider;
+import com.webproject.jandi_ide_backend.security.TokenInfo;
+import com.webproject.jandi_ide_backend.user.entity.User;
+import com.webproject.jandi_ide_backend.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ProjectService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+
+    public ProjectService(JwtTokenProvider jwtTokenProvider, UserRepository userRepository,
+                          ProjectRepository projectRepository)  {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userRepository = userRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    /**
+     * 대표 프로젝트 추가
+     * @param accessToken: 사용자 액세스 토큰
+//     * @param id: 사용자 ID
+     * @param requestDTO: 프로젝트 요청 DTO
+     * @return ProjectResponseDTO
+     */
+    public ProjectResponseDTO postProject(String accessToken, ProjectCreateRequestDTO requestDTO){
+        // 1. 토큰 검증
+        TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
+        String githubId = tokenInfo.getGithubId();
+
+        // 2. 사용자 정보 조회
+        User user = userRepository.findByGithubId(githubId).orElseThrow(() -> new CustomException(CustomErrorCodes.USER_NOT_FOUND));
+
+        // 3. 프로젝트 정보 저장
+        Project project = new Project();
+        project.setName(requestDTO.getName());
+        project.setGithubName(requestDTO.getGithubName());
+        project.setDescription(requestDTO.getDescription());
+        project.setUrl(requestDTO.getUrl());
+        project.setOwner(user);
+
+        // 4. 프로젝트 저장
+        try{
+            projectRepository.save(project);
+        } catch (Exception e) {
+            log.error("Error saving project: {}", e.getMessage());
+        }
+
+        // 5. 응답 DTO 반환
+        return convertToDTO(project);
+    }
+
+    /**
+     * 대표 프로젝트 수정
+     * @param accessToken: 사용자 액세스 토큰
+     * @param id: 프로젝트 ID
+     * @param requestDTO: 프로젝트 요청 DTO
+     * @return ProjectResponseDTO
+     */
+    public ProjectResponseDTO updateProject(String accessToken,Integer id,ProjectUpdateRequestDTO requestDTO){
+        // 1. 토큰 검증
+        TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
+        String githubId = tokenInfo.getGithubId();
+
+        // 2. 사용자 정보 조회 및 프로젝트 조회
+        User user = userRepository.findByGithubId(githubId).orElseThrow(() -> new CustomException(CustomErrorCodes.USER_NOT_FOUND));
+        Project project = projectRepository.findById(id).orElseThrow(() -> new CustomException(CustomErrorCodes.PROJECT_NOT_FOUND));
+
+        // 3. 자신의 프로젝트가 맞는지 확인
+        if(!project.getOwner().getId().equals(user.getId())){
+            throw new CustomException(CustomErrorCodes.PERMISSION_DENIED);
+        }
+
+        // 4. 프로젝트 정보 업데이트
+        project.setName(requestDTO.getName());
+        project.setDescription(requestDTO.getDescription());
+
+        // 5. 프로젝트 저장
+        try{
+            projectRepository.save(project);
+        } catch (Exception e) {
+            log.error("Error saving project: {}", e.getMessage());
+        }
+
+        // 6. 응답 DTO 반환
+        return convertToDTO(project);
+    }
+
+    public void deleteProject(String accessToken,Integer id){
+        // 1. 토큰 검증
+        TokenInfo tokenInfo = jwtTokenProvider.decodeToken(accessToken);
+        String githubId = tokenInfo.getGithubId();
+
+        // 2. 사용자 정보 조회 및 프로젝트 조회
+        User user = userRepository.findByGithubId(githubId).orElseThrow(() -> new CustomException(CustomErrorCodes.USER_NOT_FOUND));
+        Project project = projectRepository.findById(id).orElseThrow(() -> new CustomException(CustomErrorCodes.PROJECT_NOT_FOUND));
+
+        // 3. 자신의 프로젝트가 맞는지 확인
+        if(!project.getOwner().getId().equals(user.getId())){
+            throw new CustomException(CustomErrorCodes.PERMISSION_DENIED);
+        }
+
+        // 4. 프로젝트 삭제
+        try{
+            projectRepository.delete(project);
+        } catch (Exception e) {
+            throw new CustomException(CustomErrorCodes.DB_OPERATION_FAILED);
+        }
+    }
+
+
+    private ProjectResponseDTO convertToDTO(Project project) {
+        ProjectResponseDTO dto = new ProjectResponseDTO();
+        dto.setId(project.getId());
+        dto.setName(project.getName());
+        dto.setGithubName(project.getGithubName());
+        dto.setDescription(project.getDescription());
+        dto.setUrl(project.getUrl());
+        dto.setOwner(project.getOwner());
+        dto.setCreatedAt(project.getCreatedAt());
+        dto.setUpdatedAt(project.getUpdatedAt());
+        return dto;
+    }
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/user/dto/UserResponseDTO.java
@@ -15,7 +15,4 @@ public class UserResponseDTO {
     private String githubUsername;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-
-    // 기술 스택 , 선호 기업 , 대표 프로젝트는 각 DTO 생성후 추가 해야합니다.
 }

--- a/src/main/java/com/webproject/jandi_ide_backend/user/service/UserService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.webproject.jandi_ide_backend.user.service;
 
 import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
 import com.webproject.jandi_ide_backend.global.error.CustomException;
+import com.webproject.jandi_ide_backend.project.repository.ProjectRepository;
 import com.webproject.jandi_ide_backend.security.JwtTokenProvider;
 import com.webproject.jandi_ide_backend.security.TokenInfo;
 import com.webproject.jandi_ide_backend.user.dto.*;
@@ -16,23 +17,19 @@ import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Map;
+import java.util.*;
 
 @Slf4j
 @Service
 public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Value("${github.client.id}")
     private String githubClientId;
 
     @Value("${github.client.secret}")
     private String githubClientSecret;
-
-    private final UserRepository userRepository;
 
     public UserService(UserRepository userRepository, JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
@@ -303,6 +300,7 @@ public class UserService {
         userResponse.setCreatedAt(user.getCreatedAt());
         userResponse.setUpdatedAt(user.getUpdatedAt());
         userResponse.setGithubUsername(user.getGithubUsername());
+
         return userResponse;
     }
 }


### PR DESCRIPTION
## 작업내용

- CORS설정을 위해 config -> SecurityConfig에 커스텀CORS설정 및 세션을 사용하지 않도록 설정하는 코드를 추가했습니다.
- 대표 프로젝트 조회,등록,수정,삭제 API를 추가했습니다.
- 특정 프로젝트의 tree를 github API를 통해 불러오는 API추가
- blob타입의 파일의 sha를 통해 github API를 통해 인코딩된 파일내용을 반환하는 API추가