### PR TITLE
FEAT: 문제 조회 api에 page파라미터 적용 및 문제집 swagger추가

### DIFF
--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/controller/ProblemController.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/controller/ProblemController.java
@@ -1,6 +1,7 @@
 package com.webproject.jandi_ide_backend.algorithm.problem.controller;
 
 import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemDetailResponseDTO;
+import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemPageResponseDTO;
 import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemRequestDTO;
 import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemResponseDTO;
 import com.webproject.jandi_ide_backend.algorithm.problem.service.ProblemService;
@@ -18,8 +19,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name="Problem", description = "문제 관련 API")
 @RestController
@@ -42,12 +41,15 @@ public class ProblemController {
                     responseCode = "200",
                     description = "조회 성공",
                     content = @Content(
-                            array = @ArraySchema(schema = @Schema(implementation = ProblemResponseDTO.class))
+                            array = @ArraySchema(schema = @Schema(implementation = ProblemPageResponseDTO.class))
                     )
             )
     })
-    public ResponseEntity<List<ProblemResponseDTO>> findAllProblems(){
-        List<ProblemResponseDTO> problems = problemService.getProblems();
+    public ResponseEntity<ProblemPageResponseDTO> findAllProblems(
+            @RequestParam(value="page",defaultValue = "0") Integer page,
+            @RequestParam(value="size",defaultValue = "10") Integer size
+    ){
+        ProblemPageResponseDTO problems = problemService.getProblems(page,size);
         return ResponseEntity.ok(problems);
     }
 

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemDetailResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemDetailResponseDTO.java
@@ -13,6 +13,9 @@ public class ProblemDetailResponseDTO {
     @Schema(description = "문제 고유 ID", example = "1")
     private Integer id;
 
+    @Schema(description = "문제 제목", example = "A+B")
+    private String title;
+
     @Schema(description = "문제 설명", example = "주어진 정수 배열에서 가장 큰 값을 구하세요.")
     private String description;
 

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemPageResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemPageResponseDTO.java
@@ -1,0 +1,24 @@
+package com.webproject.jandi_ide_backend.algorithm.problem.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ProblemPageResponseDTO {
+    @Schema(description = "페이지에 해당하는 문제 리스트")
+    private List<ProblemResponseDTO> data;
+
+    @Schema(description = "현재 페이지",example = "0")
+    private int currentPage;
+
+    @Schema(description = "페이지당 항목 수", example = "10")
+    private int size;
+
+    @Schema(description = "전체 아이템 수",example = "50")
+    private long totalItems;
+
+    @Schema(description = "총 페이지 수",example = "5")
+    private int totalPages;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemRequestDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemRequestDTO.java
@@ -14,6 +14,9 @@ import java.util.List;
 @AllArgsConstructor
 public class ProblemRequestDTO {
 
+    @Schema(title="문제의 제목", example = "A+B")
+    private String title;
+
     @Schema(description = "문제에 대한 설명", example = "주어진 정수 배열에서 가장 큰 값을 구하세요.")
     private String description;
 

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemResponseDTO.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/dto/ProblemResponseDTO.java
@@ -12,6 +12,9 @@ public class ProblemResponseDTO {
     @Schema(description = "문제 고유 ID", example = "1")
     private Integer id;
 
+    @Schema(description = "문제 제목", example = "A+B")
+    private String title;
+
     @Schema(description = "문제 설명", example = "주어진 정수 배열에서 가장 큰 값을 구하세요.")
     private String description;
 

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/entity/Problem.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/entity/Problem.java
@@ -19,6 +19,9 @@ public class Problem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(name= "title", nullable = false)
+    private String title;
+
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/service/ProblemService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/service/ProblemService.java
@@ -59,6 +59,7 @@ public class ProblemService {
 
     public ProblemResponseDTO postProblem(ProblemRequestDTO problemRequestDTO) {
         Problem problem = new Problem();
+        problem.setTitle(problemRequestDTO.getTitle());
         problem.setDescription(problemRequestDTO.getDescription());
         problem.setLevel(problemRequestDTO.getLevel());
         problem.getTags().addAll(problemRequestDTO.getTags());
@@ -77,6 +78,7 @@ public class ProblemService {
     public ProblemResponseDTO updateProblem(ProblemRequestDTO problemRequestDTO,Integer id) {
         Problem problem = problemRepository.findById(id).orElseThrow(() -> new CustomException(CustomErrorCodes.PROBLEM_NOT_FOUND));
 
+        problem.setTitle(problemRequestDTO.getTitle());
         problem.setDescription(problemRequestDTO.getDescription());
         problem.setLevel(problemRequestDTO.getLevel());
         problem.setMemory(problemRequestDTO.getMemory());
@@ -104,6 +106,7 @@ public class ProblemService {
         ProblemDetailResponseDTO detailDTO = new ProblemDetailResponseDTO();
         detailDTO.setId(problem.getId());
         detailDTO.setDescription(problem.getDescription());
+        detailDTO.setTitle(problem.getTitle());
         detailDTO.setLevel(problem.getLevel());
         detailDTO.setMemory(problem.getMemory());
         detailDTO.setTimeLimit(problem.getTimeLimit());
@@ -146,6 +149,7 @@ public class ProblemService {
         problemResponseDTO.setTags(problem.getTags());
         problemResponseDTO.setCreatedAt(problem.getCreatedAt());
         problemResponseDTO.setUpdatedAt(problem.getUpdatedAt());
+        problemResponseDTO.setTitle(problem.getTitle());
 
         return problemResponseDTO;
     }

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/controller/ProblemSetController.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/controller/ProblemSetController.java
@@ -2,14 +2,27 @@ package com.webproject.jandi_ide_backend.algorithm.problemSet.controller;
 
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqPostProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqUpdateProblemSetDTO;
+import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.service.ProblemSetService;
 import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
 import com.webproject.jandi_ide_backend.global.error.CustomException;
 import com.webproject.jandi_ide_backend.security.JwtTokenProvider;
 import com.webproject.jandi_ide_backend.security.TokenInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Tag(name="ProblemSet",description = "문제집 관련 API")
 @RestController
 @RequestMapping("/api/problem-set")
 public class ProblemSetController {
@@ -22,9 +35,21 @@ public class ProblemSetController {
     }
 
     /// create
-    @PostMapping("")
-    public Object createProblemSet(
-            @RequestHeader("Authorization") String token,
+    @PostMapping
+    @Operation(summary = "문제집을 생성",
+            description = "문제집을 생성합니다.",
+            security = { @SecurityRequirement(name = "Authorization") })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "생성 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = RespProblemSetDTO.class)
+                    )
+            )
+    })
+    public RespProblemSetDTO createProblemSet(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token,
             @RequestBody ReqPostProblemSetDTO probSetDTO
     ) {
         String githubId = getGithubIdFromToken(token);
@@ -32,8 +57,20 @@ public class ProblemSetController {
     }
 
     /// read
-    @GetMapping("")
-    public Object readProblemSet(
+    @GetMapping
+    @Operation(summary = "문제집 목록 조회",
+            description = "사용자의 문제집 목록을 조회합니다.",
+            security = { @SecurityRequirement(name = "Authorization") })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = RespProblemSetDTO.class))
+                    )
+            )
+    })
+    public List<RespProblemSetDTO> readProblemSet(
             @RequestHeader("Authorization") String token
     ) {
         String githubId = getGithubIdFromToken(token);
@@ -42,8 +79,20 @@ public class ProblemSetController {
 
     /// update
     @PutMapping("{problemSetId}")
-    public Object updateProblemSet(
-            @RequestHeader("Authorization") String token,
+    @Operation(summary = "문제집 수정",
+            description = "특정 문제집을 수정합니다.",
+            security = { @SecurityRequirement(name = "Authorization") })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = RespProblemSetDTO.class)
+                    )
+            )
+    })
+    public RespProblemSetDTO updateProblemSet(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token,
             @PathVariable Long problemSetId,
             @RequestBody ReqUpdateProblemSetDTO probSetDTO
             ) {
@@ -53,8 +102,20 @@ public class ProblemSetController {
 
     /// delete
     @DeleteMapping("{problemSetId}")
-    public ResponseEntity<?> deleteProblemSet(
-            @RequestHeader("Authorization") String token,
+    @Operation(summary = "문제집 삭제",
+            description = "특정 문제집을 삭제합니다.",
+            security = { @SecurityRequirement(name = "Authorization") })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = String.class)
+                    )
+            )
+    })
+    public ResponseEntity<String> deleteProblemSet(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token,
             @PathVariable Long problemSetId
     ) {
         String githubId = getGithubIdFromToken(token);

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
@@ -3,8 +3,8 @@ package com.webproject.jandi_ide_backend.algorithm.problemSet.service;
 import com.webproject.jandi_ide_backend.algorithm.problem.repository.ProblemRepository;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.Repository.ProblemSetRepository;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqPostProblemSetDTO;
-import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqUpdateProblemSetDTO;
+import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.entity.ProblemSet;
 import com.webproject.jandi_ide_backend.company.entity.Company;
 import com.webproject.jandi_ide_backend.company.repository.CompanyRepository;
@@ -29,7 +29,7 @@ public class ProblemSetService {
     private final CompanyRepository companyRepository;
 
     /// API
-    public Object createProblemSet(ReqPostProblemSetDTO probSetDTO, String githubId) {
+    public RespProblemSetDTO createProblemSet(ReqPostProblemSetDTO probSetDTO, String githubId) {
         // 유저 검증
         User user = userRepository.findByGithubId(githubId)
                 .orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
@@ -63,7 +63,7 @@ public class ProblemSetService {
                 .toList();
     }
 
-    public Object updateProblemSet(Long problemSetId, ReqUpdateProblemSetDTO probSetDTO, String githubId) {
+    public RespProblemSetDTO updateProblemSet(Long problemSetId, ReqUpdateProblemSetDTO probSetDTO, String githubId) {
         // 유저 검증
         User user = userRepository.findByGithubId(githubId)
                 .orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));

--- a/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
@@ -28,6 +28,8 @@ public enum CustomErrorCodes implements CustomErrorCodeInterface {
     TESTCASE_NOT_FOUND(HttpStatus.NOT_FOUND, "TESTCASE_NOT_FOUND", "Testcase not found"),
 
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "PERMISSION_DENIED", "Permission denied"), // 권한 없음
+    INVALID_PAGE(HttpStatus.BAD_REQUEST, "INVALID_PAGE", "Invalid page"), // 유효하지 않은 페이지
+
 
 
     // 500번대 에러


### PR DESCRIPTION
## 작업내용

- 문제 조회 API에 page와 size 파라미터를 적용했습니다. 미입력시 기본값 page = 0 , size = 10 이 적용됩니다.
- Problem 테이블에 title이 추가됨에 따라 Entity,여러 Problem관련 DTO에 title을 추가했습니다.
- ProblemSet api에 swagger관련 코드를 추가했습니다.