### PR TITLE
FEAT: 기업 기출문제 랜덤문제 제공 및 특정 문제집 조회 추가

### DIFF
--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problem/repository/ProblemRepository.java
@@ -3,8 +3,11 @@ package com.webproject.jandi_ide_backend.algorithm.problem.repository;
 import com.webproject.jandi_ide_backend.algorithm.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
     Optional<Problem> findById(Integer id);
+
+    List<Problem> findByLevel(Integer level);
 }

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/controller/ProblemSetController.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/controller/ProblemSetController.java
@@ -2,6 +2,7 @@ package com.webproject.jandi_ide_backend.algorithm.problemSet.controller;
 
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqPostProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqUpdateProblemSetDTO;
+import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespDetailProblemSet;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.service.ProblemSetService;
 import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
@@ -71,10 +72,30 @@ public class ProblemSetController {
             )
     })
     public List<RespProblemSetDTO> readProblemSet(
-            @RequestHeader("Authorization") String token
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token
     ) {
         String githubId = getGithubIdFromToken(token);
         return problemSetService.readProblemSet(githubId);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "특정 문제집 조회",
+            description = "특정 문제집 목록을 조회합니다.",
+            security = { @SecurityRequirement(name = "Authorization") })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = RespDetailProblemSet.class)
+                    )
+            )
+    })
+    public RespDetailProblemSet readProblemSetDetail(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token,
+            @PathVariable Long id
+    ){
+        return problemSetService.readProblemSetDetail(id);
     }
 
     /// update

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/dto/RespDetailProblemSet.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/dto/RespDetailProblemSet.java
@@ -1,0 +1,23 @@
+package com.webproject.jandi_ide_backend.algorithm.problemSet.dto;
+
+import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemDetailResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RespDetailProblemSet {
+    private Long id;
+    private String title;
+    private Boolean isPrevious;
+    private Integer solvingTimeInMinutes;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<ProblemDetailResponseDTO> problems;
+}

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
@@ -1,10 +1,13 @@
 package com.webproject.jandi_ide_backend.algorithm.problemSet.service;
 
+import com.webproject.jandi_ide_backend.algorithm.problem.dto.ProblemDetailResponseDTO;
 import com.webproject.jandi_ide_backend.algorithm.problem.entity.Problem;
 import com.webproject.jandi_ide_backend.algorithm.problem.repository.ProblemRepository;
+import com.webproject.jandi_ide_backend.algorithm.problem.service.ProblemService;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.Repository.ProblemSetRepository;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqPostProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqUpdateProblemSetDTO;
+import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespDetailProblemSet;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetDTO;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.entity.ProblemSet;
 import com.webproject.jandi_ide_backend.company.entity.Company;
@@ -20,6 +23,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -29,6 +33,7 @@ public class ProblemSetService {
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
+    private final ProblemService problemService;
 
     /// API
     public RespProblemSetDTO createProblemSet(ReqPostProblemSetDTO probSetDTO, String githubId) {
@@ -63,6 +68,22 @@ public class ProblemSetService {
         return problemSetList.stream()
                 .map(RespProblemSetDTO::fromEntity)
                 .toList();
+    }
+
+    public RespDetailProblemSet readProblemSetDetail(Long id) {
+        ProblemSet problemSet = problemSetRepository.findById(id).orElseThrow(()->new CustomException(CustomErrorCodes.PROBLEMSET_NOT_FOUND));
+        List<ProblemDetailResponseDTO> problems = getProblemsInProblemSet(problemSet);
+
+        return new RespDetailProblemSet(
+                problemSet.getId(),
+                problemSet.getTitle(),
+                problemSet.getIsPrevious(),
+                problemSet.getSolvingTimeInMinutes(),
+                problemSet.getDescription(),
+                problemSet.getCreatedAt(),
+                problemSet.getUpdatedAt(),
+                problems
+        );
     }
 
     public RespProblemSetDTO updateProblemSet(Long problemSetId, ReqUpdateProblemSetDTO probSetDTO, String githubId) {
@@ -158,6 +179,14 @@ public class ProblemSetService {
             throw new RuntimeException("잘못된 문제를 선택하셨습니다.");
 
         return customProblems;
+    }
+
+    //문제집에 포함된 문제들의 자세한 내용을 로드
+    public List<ProblemDetailResponseDTO> getProblemsInProblemSet(ProblemSet problemSet){
+        List<Integer> problemIds = problemSet.getProblems();
+        return problemIds.stream()
+                .map(problemService::getProblemDetail)
+                .collect(Collectors.toList());
     }
 
     /// 실제 DB CRUD

--- a/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/algorithm/problemSet/service/ProblemSetService.java
@@ -1,5 +1,6 @@
 package com.webproject.jandi_ide_backend.algorithm.problemSet.service;
 
+import com.webproject.jandi_ide_backend.algorithm.problem.entity.Problem;
 import com.webproject.jandi_ide_backend.algorithm.problem.repository.ProblemRepository;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.Repository.ProblemSetRepository;
 import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.ReqPostProblemSetDTO;
@@ -8,6 +9,8 @@ import com.webproject.jandi_ide_backend.algorithm.problemSet.dto.RespProblemSetD
 import com.webproject.jandi_ide_backend.algorithm.problemSet.entity.ProblemSet;
 import com.webproject.jandi_ide_backend.company.entity.Company;
 import com.webproject.jandi_ide_backend.company.repository.CompanyRepository;
+import com.webproject.jandi_ide_backend.global.error.CustomErrorCodes;
+import com.webproject.jandi_ide_backend.global.error.CustomException;
 import com.webproject.jandi_ide_backend.user.entity.User;
 import com.webproject.jandi_ide_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -103,9 +105,34 @@ public class ProblemSetService {
 
     // 기업 문제집 - 랜덤 지정 문제 로드
     private List<Integer> setRandProblems(Company company) {
-        List<Integer> problemIds = new ArrayList<>();
-        problemIds.add(1);
-        problemIds.add(2);
+        List<Integer> problemIds = new ArrayList<>(); // 반환할 문제 id 값의 배열
+        Map<Integer, Integer> levelCountMap = new HashMap<>();
+
+        // 레벨별로 몇 개 뽑아야 하는지 세기
+        for (int level : company.getLevels()) {
+            levelCountMap.put(level, levelCountMap.getOrDefault(level, 0) + 1);
+        }
+
+        for (Map.Entry<Integer, Integer> entry : levelCountMap.entrySet()) {
+            int level = entry.getKey();
+            int count = entry.getValue();
+
+            // 레벨에 해당하는 모든 문제 가져오기
+            List<Problem> problemsByLevel = problemRepository.findByLevel(level);
+
+            // 문제 수가 부족하면 예외 처리
+            if (problemsByLevel.size() < count) {
+                throw new CustomException(CustomErrorCodes.INSUFFICIENT_PROBLEMS);
+            }
+
+            // 랜덤 셔플 후 앞에서 count 개 선택
+            Collections.shuffle(problemsByLevel);
+            List<Problem> selected = problemsByLevel.subList(0, count);
+
+            for (Problem p : selected) {
+                problemIds.add(p.getId());
+            }
+        }
 
         return problemIds;
     }

--- a/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
@@ -27,6 +27,8 @@ public enum CustomErrorCodes implements CustomErrorCodeInterface {
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM_NOT_FOUND", "Problem not found"),
     TESTCASE_NOT_FOUND(HttpStatus.NOT_FOUND, "TESTCASE_NOT_FOUND", "Testcase not found"),
 
+    INSUFFICIENT_PROBLEMS(HttpStatus.BAD_REQUEST, "INSUFFICIENT_PROBLEMS", "레벨에 맞는 문제가 부족합니다."),
+
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "PERMISSION_DENIED", "Permission denied"), // 권한 없음
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "INVALID_PAGE", "Invalid page"), // 유효하지 않은 페이지
 

--- a/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/global/error/CustomErrorCodes.java
@@ -25,6 +25,7 @@ public enum CustomErrorCodes implements CustomErrorCodeInterface {
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY_NOT_FOUND", "Company not found"), // 회사를 찾을 수 없음
     JOBPOSTING_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBPOSTING_NOT_FOUND", "Jobposting not found"),
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM_NOT_FOUND", "Problem not found"),
+    PROBLEMSET_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEMSET_NOT_FOUND", "Problem set not found"),
     TESTCASE_NOT_FOUND(HttpStatus.NOT_FOUND, "TESTCASE_NOT_FOUND", "Testcase not found"),
 
     INSUFFICIENT_PROBLEMS(HttpStatus.BAD_REQUEST, "INSUFFICIENT_PROBLEMS", "레벨에 맞는 문제가 부족합니다."),


### PR DESCRIPTION
## 작업내용

- 기업 기출문제로 문제집을 생성할시, 해당 기업의 levels에 해당하는 문제들을 랜덤으로 뽑아, 문제집을 생성합니다.
- 특정 문제집 조회시, 해당 문제집에 포함된 문제들을 디테일하게 보여줍니다. (문제 및 테스트케이스 포함)