### PR TITLE
Feat: 전체 기업 조회 시 기업 프로필 사진이 내려오지 않는 오류 수정

### DIFF
--- a/src/main/java/com/webproject/jandi_ide_backend/company/service/CompanyService.java
+++ b/src/main/java/com/webproject/jandi_ide_backend/company/service/CompanyService.java
@@ -163,7 +163,7 @@ public class CompanyService {
         responseDTO.setProgrammingLanguages(company.getProgrammingLanguages());
         responseDTO.setCreatedAt(company.getCreatedAt());
         responseDTO.setUpdatedAt(company.getUpdatedAt());
-
+        responseDTO.setProfileUrl(company.getProfileUrl());
         return responseDTO;
     }
 


### PR DESCRIPTION
이미지를 넣었는데도 전체 기업 조회 시 프로필 사진 url이 내려오지 않아서 찾아보니 dto만 수정하는게 아니더라구요... 서비스 로직 수정해서 url 내려오도록 바꿨습니다!