### PR TITLE
fix(docker): openjdk 이미지를 eclipse-temurin으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew build --no-daemon -x test
 
 # Runtime stage
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre
 
 # 패키지 설치
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- openjdk:17-jdk-slim 이미지가 Docker Hub에서 제거됨
- eclipse-temurin:17-jre로 대체 (런타임만 필요하므로 JRE 사용)